### PR TITLE
12 us

### DIFF
--- a/app/controllers/cities_controller.rb
+++ b/app/controllers/cities_controller.rb
@@ -21,6 +21,16 @@ class CitiesController < ApplicationController
     redirect_to '/cities'
   end
 
+  def edit
+    @city= City.find(params[:id])
+  end
+
+  def update
+    city = City.find(params[:id])
+    city.update(city_params)
+    redirect_to "/cities/#{city.id}"
+  end
+
   private
   def city_params
     params.permit(:name, :population, :metropolis)

--- a/app/views/cities/edit.html.erb
+++ b/app/views/cities/edit.html.erb
@@ -1,0 +1,9 @@
+<%= form_with url: "/cities/#{@city.id}/edit", method: :patch, local: true do |form| %>
+  <%= form.label :name %>
+  <%= form.text_field :name %>
+  <%= form.label :population %>
+  <%= form.text_field :population %>
+  <%= form.label :metropolis %>
+  <%= form.text_field :metropolis %>
+  <%= form.submit 'Update City' %>
+<% end %>

--- a/app/views/cities/show.html.erb
+++ b/app/views/cities/show.html.erb
@@ -3,3 +3,4 @@
 <p>Metropolis: <%= @city.metropolis %></p>
 <p>Number of Restaurants: <%= @city.restaurant_count %></p>
 <%= button_to "Restaurants in #{@city.name}", "/cities/#{@city.id}/restaurants", method: :get%>
+<%= link_to "Edit City", "/cities/#{@city.id}/edit" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,6 @@ Rails.application.routes.draw do
   get '/restaurants/:id', to: 'restaurants#show'
   get '/cities/:id/restaurants', to: 'cities#city_restaurant_index'
   post '/cities', to: 'cities#create'
+  get '/cities/:id/edit', to: 'cities#edit'
+  patch '/cities/:id/edit', to: 'cities#update'
 end

--- a/spec/features/cities/show_spec.rb
+++ b/spec/features/cities/show_spec.rb
@@ -26,4 +26,22 @@ RSpec.describe 'shows index of a city' do
   
     expect(page).to have_content(@braselton.restaurant_count)
   end
+
+  it 'has a link to update the city' do
+    hoschton = City.create!(name: 'Hoshton', population: 12450, metropolis:false) 
+    visit "/cities/#{hoschton.id}"
+
+    click_link "Edit City"
+
+    expect(current_path).to eq("/cities/#{hoschton.id}/edit")
+
+    fill_in "Name", with: "Hoschton"
+    fill_in "Population", with: 12450
+    fill_in "Metropolis", with: false
+
+    click_on "Update City"
+
+    expect(current_path).to eq("/cities/#{hoschton.id}")
+    expect(page).to have_content("Hoschton")
+  end
 end


### PR DESCRIPTION
User Story 12, Parent Update 

As a visitor
When I visit a parent show page
Then I see a link to update the parent "Update Parent"
When I click the link "Update Parent"
Then I am taken to '/parents/:id/edit' where I  see a form to edit the parent's attributes:
When I fill out the form with updated information
And I click the button to submit the form
Then a `PATCH` request is sent to '/parents/:id',
the parent's info is updated,
and I am redirected to the Parent's Show page where I see the parent's updated info