### PR TITLE
13 us

### DIFF
--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -6,4 +6,19 @@ class RestaurantsController < ApplicationController
   def show
     @restaurant = Restaurant.find(params[:id])
   end
+
+  def new
+    @city = City.find(params[:city_id])
+  end
+
+  def create
+    city = City.find(params[:city_id])
+    restaurant = city.restaurants.create!(restaurant_params)
+    redirect_to "/cities/#{restaurant.city_id}/restaurants"
+  end
+
+  private
+  def restaurant_params
+    params.permit(:name, :food_type, :alcohol_served, :rating)
+  end
 end

--- a/app/views/cities/city_restaurant_index.html.erb
+++ b/app/views/cities/city_restaurant_index.html.erb
@@ -6,3 +6,4 @@
   <p>Alcohol?: <%= restaurant.alcohol_served %></p>
   <p>Rating: <%= restaurant.rating %></p>
 <% end %>
+<%= link_to "Add New Restaurant", "/cities/#{@city.id}/restaurants/new" %>

--- a/app/views/restaurants/new.html.erb
+++ b/app/views/restaurants/new.html.erb
@@ -1,0 +1,11 @@
+<%= form_with url: "/cities/#{@city.id}/restaurants", method: :post, local: true do |form| %>
+  <%= form.label :name %>
+  <%= form.text_field :name %><br>
+  <%= form.label :food_type %>
+  <%= form.text_field :food_type %><br>
+  <%= form.label :alcohol_served %>
+  <%= form.text_field :alcohol_served %><br>
+  <%= form.label :rating %>
+  <%= form.text_field :rating %><br>
+  <%= form.submit 'Create Restaurant' %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,6 @@ Rails.application.routes.draw do
   post '/cities', to: 'cities#create'
   get '/cities/:id/edit', to: 'cities#edit'
   patch '/cities/:id/edit', to: 'cities#update'
+  get '/cities/:city_id/restaurants/new', to: 'restaurants#new'
+  post 'cities/:city_id/restaurants', to: 'restaurants#create'
 end

--- a/spec/features/cities/restaurants/index_spec.rb
+++ b/spec/features/cities/restaurants/index_spec.rb
@@ -20,4 +20,20 @@ RSpec.describe 'Restaurant in city' do
     click_button "Restaurants in #{@braselton.name}"
     expect(current_path).to eq("/cities/#{@braselton.id}/restaurants")
   end
+  
+  it 'shows a link to add a new restaurant to the city' do
+    visit "/cities/#{@braselton.id}/restaurants"
+    
+    click_link "Add New Restaurant"
+
+    expect(current_path).to eq("/cities/#{@braselton.id}/restaurants/new")
+    fill_in :name, with: 'Cotton Calf'
+    fill_in :food_type, with: 'Steakhouse'
+    fill_in :alcohol_served, with: true
+    fill_in :rating, with: 5
+
+    click_on "Create Restaurant"
+    expect(current_path).to eq("/cities/#{@braselton.id}/restaurants")
+    expect(page).to have_content("Cotton Calf")
+  end
 end


### PR DESCRIPTION
User Story 13, Parent Child Creation 

As a visitor
When I visit a Parent Children Index page
Then I see a link to add a new adoptable child for that parent "Create Child"
When I click the link
I am taken to '/parents/:parent_id/child_table_name/new' where I see a form to add a new adoptable child
When I fill in the form with the child's attributes:
And I click the button "Create Child"
Then a `POST` request is sent to '/parents/:parent_id/child_table_name',
a new child object/row is created for that parent,
and I am redirected to the Parent Childs Index page where I can see the new child listed