### PR TITLE
17 us

### DIFF
--- a/app/views/cities/edit.html.erb
+++ b/app/views/cities/edit.html.erb
@@ -1,9 +1,9 @@
 <%= form_with url: "/cities/#{@city.id}/edit", method: :patch, local: true do |form| %>
   <%= form.label :name %>
-  <%= form.text_field :name %>
+  <%= form.text_field :name %><br>
   <%= form.label :population %>
-  <%= form.text_field :population %>
+  <%= form.text_field :population %><br>
   <%= form.label :metropolis %>
-  <%= form.text_field :metropolis %>
+  <%= form.text_field :metropolis %><br>
   <%= form.submit 'Update City' %>
 <% end %>

--- a/app/views/cities/index.html.erb
+++ b/app/views/cities/index.html.erb
@@ -1,6 +1,8 @@
 <h1>All Cities<h1>
 
 <% @cities.each do |city| %>
-  <h3><%= city.name %>  | created at: <%= city.created_at %></h3>
+  <h3><%= city.name %></h3>
+  <p>Created at: <%= city.created_at %></p><br>
+  <%= link_to "Update #{city.name}", "/cities/#{city.id}/edit" %>
 <% end %>
 <%= link_to "New City", "/cities/new" %>

--- a/spec/features/cities/index_spec.rb
+++ b/spec/features/cities/index_spec.rb
@@ -43,4 +43,24 @@ RSpec.describe 'shows index of all cities' do
     expect(current_path).to eq("/cities")
     expect(page).to have_content("Charleston")
   end
+
+  it 'has a link to update a city' do
+    braselton = City.create!(name:'Braselton', population:12178, metropolis:false)
+    atlanta = City.create!(name:'Atlanta', population:497642, metropolis:true)
+
+    visit '/cities'
+
+    click_link "Update #{braselton.name}"
+
+    expect(current_path).to eq("/cities/#{braselton.id}/edit")
+    fill_in :name, with: 'Braselton'
+    fill_in :population, with: 12148
+    fill_in :metropolis, with: false
+
+    click_on "Update City"
+    
+    expect(current_path).to eq("/cities/#{braselton.id}")
+    expect(page).to have_content(12148)
+    expect(page).to_not have_content(12178)
+  end
 end


### PR DESCRIPTION
User Story 17, Parent Update From Parent Index Page 

As a visitor
When I visit the parent index page
Next to every parent, I see a link to edit that parent's info
When I click the link
I should be taken to that parent's edit page where I can update its information just like in User Story 12

Tests pass