### PR TITLE
18 us

### DIFF
--- a/app/views/cities/city_restaurant_index.html.erb
+++ b/app/views/cities/city_restaurant_index.html.erb
@@ -7,5 +7,6 @@
   <p>Food Type: <%= restaurant.food_type %></p>
   <p>Alcohol?: <%= restaurant.alcohol_served %></p>
   <p>Rating: <%= restaurant.rating %></p>
+  <%= link_to "Update #{restaurant.name}", "/restaurants/#{restaurant.id}/edit" %>
 <% end %>
 <%= link_to "Add New Restaurant", "/cities/#{@city.id}/restaurants/new" %>

--- a/app/views/restaurants/index.html.erb
+++ b/app/views/restaurants/index.html.erb
@@ -6,4 +6,5 @@
   <p>Food Type: <%= restaurant.food_type %></p>
   <p>Alcohol?: <%= restaurant.alcohol_served %></p>
   <p>5 Star Rating: <%= restaurant.rating %></p>
+  <%= link_to "Update #{restaurant.name}", "/restaurants/#{restaurant.id}/edit" %>
 <% end %>

--- a/spec/features/cities/restaurants/index_spec.rb
+++ b/spec/features/cities/restaurants/index_spec.rb
@@ -46,4 +46,22 @@ RSpec.describe 'Restaurant in city' do
     expect(current_path).to eq("/cities/#{@braselton.id}/restaurants")
     expect(@jacks.name).to appear_before(@zaxbys.name)
   end
+
+  it 'shows a link to update a restaurant in that city' do
+    visit "/cities/#{@atlanta.id}/restaurants"
+
+    click_link "Update #{@fogo.name}"
+
+    expect(current_path).to eq("/restaurants/#{@fogo.id}/edit")
+    fill_in :name, with: "Fogo de Chao"
+    fill_in :food_type, with: "Steakhouse"
+    fill_in :alcohol_served, with: true
+    fill_in :rating, with: 5
+
+    click_on "Update Restaurant"
+
+    expect(current_path).to eq("/restaurants/#{@fogo.id}")
+    expect(page).to have_content("Steakhouse")
+    expect(page).to_not have_content("steak house")
+  end
 end

--- a/spec/features/restaurants/index_spec.rb
+++ b/spec/features/restaurants/index_spec.rb
@@ -36,4 +36,27 @@ RSpec.describe 'shows index of all restaurants' do
 
     expect(page).to_not have_content("Zaxbys")
   end
+
+  it 'has a link to update the restaurant' do
+    braselton = City.create!(name:'Braselton', population:12178, metropolis:false)
+    atlanta = City.create!(name:'Atlanta', population:49762, metropolis:true)
+    fogo = atlanta.restaurants.create!(name: 'Fogo de Chao', food_type: 'steak house', alcohol_served: true, rating: 5)
+    jacks = braselton.restaurants.create!(name: 'Jacks Public House', food_type:'American', alcohol_served: true, rating: 5)
+
+    visit "/restaurants"
+
+    click_link "Update #{fogo.name}"
+
+    expect(current_path).to eq("/restaurants/#{fogo.id}/edit")
+    fill_in :name, with: "Fogo de Chao"
+    fill_in :food_type, with: "Steakhouse"
+    fill_in :alcohol_served, with: true
+    fill_in :rating, with: 5
+
+    click_on "Update Restaurant"
+
+    expect(current_path).to eq("/restaurants/#{fogo.id}")
+    expect(page).to have_content("Steakhouse")
+    expect(page).to_not have_content("steak house")
+  end
 end


### PR DESCRIPTION
User Story 18, Child Update From Childs Index Page 

As a visitor
When I visit the `child_table_name` index page or a parent `child_table_name` index page
Next to every child, I see a link to edit that child's info
When I click the link
I should be taken to that `child_table_name` edit page where I can update its information just like in User Story 14

Tests pass