### PR TITLE
19 us

### DIFF
--- a/app/controllers/cities_controller.rb
+++ b/app/controllers/cities_controller.rb
@@ -34,6 +34,11 @@ class CitiesController < ApplicationController
     redirect_to "/cities/#{city.id}"
   end
 
+  def destroy
+    City.destroy(params[:id])
+    redirect_to "/cities"
+  end
+
   private
   def city_params
     params.permit(:name, :population, :metropolis)

--- a/app/views/cities/edit.html.erb
+++ b/app/views/cities/edit.html.erb
@@ -1,9 +1,9 @@
 <%= form_with url: "/cities/#{@city.id}/edit", method: :patch, local: true do |form| %>
   <%= form.label :name %>
-  <%= form.text_field :name %><br>
+  <%= form.text_field :name, value: @city.name %><br>
   <%= form.label :population %>
-  <%= form.text_field :population %><br>
+  <%= form.text_field :population, value: @city.population %><br>
   <%= form.label :metropolis %>
-  <%= form.text_field :metropolis %><br>
+  <%= form.text_field :metropolis, value: @city.metropolis %><br>
   <%= form.submit 'Update City' %>
 <% end %>

--- a/app/views/cities/index.html.erb
+++ b/app/views/cities/index.html.erb
@@ -1,8 +1,9 @@
 <h1>All Cities<h1>
 
 <% @cities.each do |city| %>
-  <h3><%= city.name %></h3>
-  <p>Created at: <%= city.created_at %></p><br>
-  <%= link_to "Update #{city.name}", "/cities/#{city.id}/edit" %>
+  <h2><%= city.name %></h2>
+  <p><%= link_to "More info on #{city.name}", "/cities/#{city.id}" %></p>
+  <p>Created at: <%= city.created_at %></p>
+  <p><%= link_to "Update #{city.name}", "/cities/#{city.id}/edit" %></p>
 <% end %>
 <%= link_to "New City", "/cities/new" %>

--- a/app/views/cities/show.html.erb
+++ b/app/views/cities/show.html.erb
@@ -3,4 +3,5 @@
 <p>Metropolis: <%= @city.metropolis %></p>
 <p>Number of Restaurants: <%= @city.restaurant_count %></p>
 <%= button_to "Restaurants in #{@city.name}", "/cities/#{@city.id}/restaurants", method: :get%>
+<%= button_to "Delete", "/cities/#{@city.id}", method: :delete %>
 <%= link_to "Edit City", "/cities/#{@city.id}/edit" %>

--- a/app/views/restaurants/edit.html.erb
+++ b/app/views/restaurants/edit.html.erb
@@ -1,11 +1,11 @@
 <%= form_with url: "/restaurants/#{@restaurant.id}", method: :patch, local: true do |form| %>
   <%= form.label :name %>
-  <%= form.text_field :name %><br>
+  <%= form.text_field :name, value: @restaurant.name %><br>
   <%= form.label :food_type %>
-  <%= form.text_field :food_type %><br>
+  <%= form.text_field :food_type, value: @restaurant.food_type %><br>
   <%= form.label :alcohol_served %>
-  <%= form.text_field :alcohol_served %><br>
+  <%= form.text_field :alcohol_served, value: @restaurant.alcohol_served %><br>
   <%= form.label :rating %>
-  <%= form.text_field :rating %><br>
+  <%= form.text_field :rating, value: @restaurant.rating %><br>
   <%= form.submit 'Update Restaurant' %>
 <% end %>

--- a/app/views/restaurants/index.html.erb
+++ b/app/views/restaurants/index.html.erb
@@ -1,10 +1,10 @@
 <h1>Restaurants</h1>
 
 <% @restaurants.each do |restaurant| %>
-  <h3><%= restaurant.name %></h3>
-  <p>City: <%= restaurant.city.name %></p>
-  <p>Food Type: <%= restaurant.food_type %></p>
-  <p>Alcohol?: <%= restaurant.alcohol_served %></p>
-  <p>5 Star Rating: <%= restaurant.rating %></p>
+  <h2><ul><%= restaurant.name %></ul></h2>
+    <li>City: <%= restaurant.city.name %></lli>
+    <li>Food Type: <%= restaurant.food_type %></li>
+    <li>Alcohol?: <%= restaurant.alcohol_served %></li>
+    <li>5 Star Rating: <%= restaurant.rating %></li>
   <%= link_to "Update #{restaurant.name}", "/restaurants/#{restaurant.id}/edit" %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,4 +15,5 @@ Rails.application.routes.draw do
   post 'cities/:city_id/restaurants', to: 'restaurants#create'
   get '/restaurants/:id/edit', to: 'restaurants#edit'
   patch '/restaurants/:id', to: 'restaurants#update'
+  delete '/cities/:id', to: 'cities#destroy'
 end

--- a/spec/features/cities/index_spec.rb
+++ b/spec/features/cities/index_spec.rb
@@ -63,4 +63,17 @@ RSpec.describe 'shows index of all cities' do
     expect(page).to have_content(12148)
     expect(page).to_not have_content(12178)
   end
+
+  it 'has a link to take to the show page' do
+    braselton = City.create!(name:'Braselton', population:12178, metropolis:false)
+    atlanta = City.create!(name:'Atlanta', population:497642, metropolis:true)
+    
+    visit "/cities"
+
+    click_link "More info on #{braselton.name}"
+
+    expect(current_path).to eq("/cities/#{braselton.id}")
+    expect(page).to have_content(12178)
+    expect(page).to have_content(false)
+  end
 end

--- a/spec/features/cities/show_spec.rb
+++ b/spec/features/cities/show_spec.rb
@@ -44,4 +44,15 @@ RSpec.describe 'shows index of a city' do
     expect(current_path).to eq("/cities/#{hoschton.id}")
     expect(page).to have_content("Hoschton")
   end
+
+  it 'has a link to delete the city' do
+    hoschton = City.create!(name: 'Hoschton', population: 12450, metropolis:false) 
+    
+    visit "/cities/#{hoschton.id}"
+
+    click_button "Delete"
+
+    expect(current_path).to eq("/cities")
+    expect(page).to_not have_content(hoschton.name)
+  end
 end


### PR DESCRIPTION
User Story 19, Parent Delete 

As a visitor
When I visit a parent show page
Then I see a link to delete the parent
When I click the link "Delete Parent"
Then a 'DELETE' request is sent to '/parents/:id',
the parent is deleted, and all child records are deleted
and I am redirected to the parent index page where I no longer see this parent

UPDATE
Forms to update cities and restaurants autofill with previous information

TEST
All tests pass