### PR TITLE
22 us

### DIFF
--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -1,5 +1,5 @@
 class City < ApplicationRecord
-  has_many :restaurants
+  has_many :restaurants, :dependent => :destroy
 
   def restaurant_count
     restaurants.count

--- a/app/views/cities/index.html.erb
+++ b/app/views/cities/index.html.erb
@@ -5,5 +5,6 @@
   <p><%= link_to "More info on #{city.name}", "/cities/#{city.id}" %></p>
   <p>Created at: <%= city.created_at %></p>
   <p><%= link_to "Update #{city.name}", "/cities/#{city.id}/edit" %></p>
+  <%= button_to "Delete #{city.name}", "/cities/#{city.id}", method: :delete %>
 <% end %>
 <%= link_to "New City", "/cities/new" %>

--- a/spec/features/cities/index_spec.rb
+++ b/spec/features/cities/index_spec.rb
@@ -76,4 +76,16 @@ RSpec.describe 'shows index of all cities' do
     expect(page).to have_content(12178)
     expect(page).to have_content(false)
   end
+
+  it 'has a button to delete a city' do
+    braselton = City.create!(name:'Braselton', population:12178, metropolis:false)
+    atlanta = City.create!(name:'Atlanta', population:497642, metropolis:true)
+
+    visit "/cities"
+
+    click_button "Delete #{braselton.name}"
+
+    expect(current_path).to eq("/cities")
+    expect(page).to_not have_content(braselton.name)
+  end
 end


### PR DESCRIPTION
User Story 22, Parent Delete From Parent Index Page 

As a visitor
When I visit the parent index page
Next to every parent, I see a link to delete that parent
When I click the link
I am returned to the Parent Index Page where I no longer see that parent

TESTS
All tests pass