### PR TITLE
23 us

### DIFF
--- a/app/views/restaurants/index.html.erb
+++ b/app/views/restaurants/index.html.erb
@@ -7,4 +7,5 @@
     <li>Alcohol?: <%= restaurant.alcohol_served %></li>
     <li>5 Star Rating: <%= restaurant.rating %></li>
   <%= link_to "Update #{restaurant.name}", "/restaurants/#{restaurant.id}/edit" %>
+  <%= button_to "Delete #{restaurant.name}", "/restaurants/#{restaurant.id}", method: :delete %>
 <% end %>

--- a/spec/features/restaurants/index_spec.rb
+++ b/spec/features/restaurants/index_spec.rb
@@ -73,4 +73,18 @@ RSpec.describe 'shows index of all restaurants' do
     expect(current_path).to eq("/restaurants/#{fogo.id}")
     expect(page).to have_content(fogo.name)
   end
+
+  it 'has a button to delete the restaurant' do
+    braselton = City.create!(name:'Braselton', population:12178, metropolis:false)
+    atlanta = City.create!(name:'Atlanta', population:49762, metropolis:true)
+    fogo = atlanta.restaurants.create!(name: 'Fogo de Chao', food_type: 'steak house', alcohol_served: true, rating: 5)
+    jacks = braselton.restaurants.create!(name: 'Jacks Public House', food_type:'American', alcohol_served: true, rating: 5)
+
+    visit "/restaurants"
+
+    click_button "Delete #{jacks.name}"
+
+    expect(current_path).to eq("/restaurants")
+    expect(page).to_not have_content(jacks.name)
+  end
 end


### PR DESCRIPTION
User Story 23, Child Delete From Childs Index Page 

As a visitor
When I visit the `child_table_name` index page or a parent `child_table_name` index page
Next to every child, I see a link to delete that child
When I click the link
I should be taken to the `child_table_name` index page where I no longer see that child

TEST
All tests pass